### PR TITLE
chore: add pre-commit ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,18 @@ updates:
       npm:
         patterns:
           - "*"
+
+    # Maintain dependencies for pre-commit
+    - package-ecosystem: "pre-commit"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+          day: "friday"
+          time: "00:30"
+      target-branch: "main"
+      assignees:
+          - "hibare"
+      groups:
+          pre-commit:
+              patterns:
+                  - "*"


### PR DESCRIPTION
Adds Dependabot configuration for pre-commit hooks.

Pre-commit hooks will now be automatically checked for updates on a monthly schedule.